### PR TITLE
docs: convert to archive style

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,25 @@
-![](https://heatbadger.now.sh/github/readme/contributte/apitte-fullstack/)
+![](https://heatbadger.now.sh/github/readme/contributte/apitte-fullstack/?deprecated=1)
 
 <p align=center>
-  <a href="https://github.com/apitte/fullstack/actions"><img src="https://badgen.net/github/checks/apitte/fullstack/master?cache=300"></a>
-  <a href="https://coveralls.io/r/apitte/fullstack"> <img src="https://badgen.net/coveralls/c/github/apitte/fullstack?cache=300"> </a>
-  <a href="https://packagist.org/packages/apitte/fullstack"> <img src="https://badgen.net/packagist/dm/apitte/fullstack"> </a>
-  <a href="https://packagist.org/packages/apitte/fullstack"> <img src="https://badgen.net/packagist/v/apitte/fullstack"> </a>
+    <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
+    <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
+    <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
 </p>
-<p align=center>
-  <a href="https://packagist.org/packages/apitte/fullstack"><img src="https://badgen.net/packagist/php/apitte/fullstack"></a>
-  <a href="https://github.com/contributte/apitte-fullstack"><img src="https://badgen.net/github/license/contributte/apitte-fullstack"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://bit.ly/cttfo"><img src="https://badgen.net/badge/support/forum/yellow"></a>
-  <a href="https://contributte.org/partners.html"><img src="https://badgen.net/badge/become/a%20patron/F96854"></a>
-<p>
 
 <p align=center>
-Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
+    Website 🚀 <a href="https://contributte.org">contributte.org</a> | Contact 👨🏻‍💻 <a href="https://f3l1x.io">f3l1x.io</a> | Twitter 🐦 <a href="https://twitter.com/contributte">@contributte</a>
 </p>
+
+## Disclaimer
+
+| :warning: | This project is no longer being maintained. Please use [contributte/apitte](https://github.com/contributte/apitte).|
+|---|---|
+
+| Composer | [`apitte/fullstack`](https://packagist.org/apitte/fullstack) |
+|---| --- |
+| Version | ![](https://badgen.net/packagist/v/apitte/fullstack) |
+| PHP | ![](https://badgen.net/packagist/php/apitte/fullstack) |
+| License | ![](https://badgen.net/github/license/contributte/apitte-fullstack) |
 
 ## Usage
 
@@ -35,9 +38,7 @@ composer require apitte/fullstack
 
 ## Development
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
-
-This package is currently maintaining by these authors.
+This package was maintain by these authors.
 
 <a href="https://github.com/f3l1x">
   <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
@@ -46,4 +47,4 @@ This package is currently maintaining by these authors.
 -----
 
 Consider to [support](https://contributte.org/partners.html) **contributte** development team.
-Also thank you for using this package.
+Also thank you for being used this package.


### PR DESCRIPTION
## Summary
- Converted README.md to archive style format
- Added deprecation badge with `?deprecated=1`
- Simplified header badges (gitter, forum, donations)
- Added disclaimer section pointing to `contributte/apitte`
- Added Composer package info table
- Changed Development section to past tense

## Test plan
- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)